### PR TITLE
Initial network listener implementation

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+)
+
+func handleConnection(conn net.Conn) {
+	defer conn.Close()
+	// Maximum request is 1024 bytes.
+	request := make([]byte, 1024)
+	_, err := bufio.NewReader(conn).Read(request)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	// Print the request
+	fmt.Println(request)
+	// Send ACK response
+	_, err = bufio.NewWriter(conn).WriteString("Ack")
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+}
+
+func main() {
+	// By default, the gateway listens to port 8080
+	ln, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			fmt.Println(err.Error())
+			continue
+		}
+		go handleConnection(conn)
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"net"
 )
@@ -10,15 +9,15 @@ func handleConnection(conn net.Conn) {
 	defer conn.Close()
 	// Maximum request is 1024 bytes.
 	request := make([]byte, 1024)
-	_, err := bufio.NewReader(conn).Read(request)
+	n, err := conn.Read(request)
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 	// Print the request
-	fmt.Println(request)
+	fmt.Println(string(request[:n]))
 	// Send ACK response
-	_, err = bufio.NewWriter(conn).WriteString("Ack")
+	_, err = conn.Write([]byte("ACK"))
 	if err != nil {
 		fmt.Println(err.Error())
 	}


### PR DESCRIPTION
Initial code for network listener. 
It listens to port 8080, prints request, and replies with an ACK.