### PR TITLE
Decouple incoming & outgoing tcp requests.

### DIFF
--- a/internal/api/gatewayapi/dht_discover.go
+++ b/internal/api/gatewayapi/dht_discover.go
@@ -1,8 +1,8 @@
 package gatewayapi
 
 import (
-	"bufio"
 	"encoding/json"
+	"net"
 	"time"
 
 	"github.com/ConsenSys/fc-retrieval-gateway/internal/gateway"
@@ -10,7 +10,7 @@ import (
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
 )
 
-func handleGatewayDHTDiscoverRequest(reader *bufio.Reader, writer *bufio.Writer, request *messages.GatewayDHTDiscoverRequest) error {
+func handleGatewayDHTDiscoverRequest(conn net.Conn, request *messages.GatewayDHTDiscoverRequest) error {
 	// First check if the message can be discarded.
 	if time.Now().Unix() > request.TTL {
 		// Message discarded.
@@ -48,5 +48,5 @@ func handleGatewayDHTDiscoverRequest(reader *bufio.Reader, writer *bufio.Writer,
 	response.Signature = "TODO" // TODO, Sign the fields
 	// Send message
 	data, _ := json.Marshal(response)
-	return tcpcomms.SendTCPMessage(writer, messages.GatewayDHTDiscoverResponseType, data)
+	return tcpcomms.SendTCPMessage(conn, messages.GatewayDHTDiscoverResponseType, data, timeoutDefault*time.Millisecond)
 }

--- a/internal/api/gatewayapi/dht_discover.go
+++ b/internal/api/gatewayapi/dht_discover.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ConsenSys/fc-retrieval-gateway/internal/gateway"
+	"github.com/ConsenSys/fc-retrieval-gateway/internal/util/settings"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/messages"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
 )
@@ -48,5 +49,5 @@ func handleGatewayDHTDiscoverRequest(conn net.Conn, request *messages.GatewayDHT
 	response.Signature = "TODO" // TODO, Sign the fields
 	// Send message
 	data, _ := json.Marshal(response)
-	return tcpcomms.SendTCPMessage(conn, messages.GatewayDHTDiscoverResponseType, data, timeoutDefault*time.Millisecond)
+	return tcpcomms.SendTCPMessage(conn, messages.GatewayDHTDiscoverResponseType, data, settings.DefaultTCPInactivityTimeoutMs*time.Millisecond)
 }

--- a/internal/api/gatewayapi/gateway_api.go
+++ b/internal/api/gatewayapi/gateway_api.go
@@ -1,7 +1,6 @@
 package gatewayapi
 
 import (
-	"bufio"
 	"encoding/json"
 	"net"
 	"sync"
@@ -11,8 +10,12 @@ import (
 	"github.com/ConsenSys/fc-retrieval-gateway/internal/util/settings"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/logging"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/messages"
+	"github.com/ConsenSys/fc-retrieval-gateway/pkg/nodeid"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
 )
+
+// Default timeout for read/write. Unit is in milliseconds.
+const timeoutDefault = 100
 
 // StartGatewayAPI starts the TCP API as a separate go routine.
 func StartGatewayAPI(settings settings.AppSettings, g *gateway.Gateway) error {
@@ -29,191 +32,70 @@ func StartGatewayAPI(settings settings.AppSettings, g *gateway.Gateway) error {
 				continue
 			}
 			logging.Info("Incoming connection from gateway at :%s", conn.RemoteAddr())
-			go handleGatewayCommunication(conn, g)
+			go handleIncomingGatewayConnection(conn, g)
 		}
 	}(ln)
 	logging.Info("Listening on %s for connections from Gateways", settings.BindGatewayAPI)
 	return nil
 }
 
-func handleGatewayCommunication(conn net.Conn, g *gateway.Gateway) {
-	// Initialise a reader and a writer
-	reader := bufio.NewReader(conn)
-	writer := bufio.NewWriter(conn)
-	// Init struct, Set register status to false
-	gComms := gateway.CommunicationChannels{
-		CommsLock:                 sync.RWMutex{},
-		InterruptRequestChan:      make(chan bool),
-		InterruptResponseChan:     make(chan bool),
-		CommsRequestChan:          make(chan []byte),
-		CommsResponseChan:         make(chan []byte),
-		CommsResponseError:        make(chan error),
-		CommsResponseErrorIgnored: make(chan bool),
-	}
-	registered := false
+func handleIncomingGatewayConnection(conn net.Conn, g *gateway.Gateway) {
+	// Close connection on exit.
 	defer conn.Close()
-	// Start a go routine checks if any new message from the other gateway
-	triggerChan, controlChan := startDetectingRequest(reader)
-	// switch off control chan on exit to close routine.
-	defer func(controlChan chan bool) {
-		controlChan <- false
-	}(controlChan)
-	// Start detecting
-	controlChan <- true
-	// There are two states, listening mode and interrupt mode.
-	// By default, the thread is in listening mode.
-	listening := true
-	// Start loop
+
+	// Loop until error occurs and connection is dropped.
 	for {
-		switch listening {
-		case true:
-			// This is in listening mode.
-			select {
-			case <-triggerChan:
-				// There is a message received.
-				msgType, data, err := tcpcomms.ReadTCPMessage(reader)
-				if err != nil {
-					// Connection error can not be ignored here. exit the routine.
+		msgType, data, err := tcpcomms.ReadTCPMessage(conn, timeoutDefault*time.Millisecond)
+		if err != nil && !tcpcomms.IsTimeoutError(err) {
+			// Error in tcp communication, drop the connection.
+			logging.Error1(err)
+			return
+		}
+		if msgType == messages.GatewayDHTDiscoverRequestType {
+			request := messages.GatewayDHTDiscoverRequest{}
+			if json.Unmarshal(data, &request) == nil {
+				// Message is valid.
+				err = handleGatewayDHTDiscoverRequest(conn, &request)
+				if err != nil && !tcpcomms.IsTimeoutError(err) {
+					// Error in tcp communication, drop the connection.
 					logging.Error1(err)
 					return
 				}
-				// No error in reading the message.
-				if msgType == messages.GatewayDHTDiscoverRequestType {
-					request := messages.GatewayDHTDiscoverRequest{}
-					if json.Unmarshal(data, &request) != nil {
-						logging.Warn("Message from gateway: %s can not be parsed.\n", conn.RemoteAddr())
-						err = tcpcomms.SendInvalidMessage(writer)
-						if err != nil {
-							// This error can not be ignored. exit the routine.
-							logging.Error1(err)
-							return
-						}
-						// Unable to parse json error can be ignored. continue
-						controlChan <- true
-						continue
-					}
-					// Request is legal and correct.
-					if !registered {
-						// Haven’t registered yet.
-						err = gateway.RegisterGatewayCommunication(&request.GatewayID, &gComms)
-						if err != nil {
-							// This gateway can not be registered, exit the routine
-							logging.Error1(err)
-							return
-						}
-						// Deregister upon exiting the routine
-						defer gateway.DeregisterGatewayCommunication(&request.GatewayID)
-					}
-					// Handle request
-					err = handleGatewayDHTDiscoverRequest(reader, writer, &request)
-					if err != nil {
-						// Connection error can not be ignored here. exit the routine.
-						logging.Error1(err)
-						return
-					}
-				} else {
-					logging.Warn("Message from gateway: %s is of wrong type", conn.RemoteAddr())
-					err = tcpcomms.SendInvalidMessage(writer)
-					if err != nil {
-						// Connection error can not be ignored here. exit the routine.
-						logging.Error1(err)
-						return
-					}
-				}
-				// The request has been handled properly. Resume the detecting routine.
-				controlChan <- true
-			case interrupt := <-gComms.InterruptRequestChan:
-				if interrupt {
-					// Pause the detecting routine.
-					controlChan <- true
-					// Switch the state to interrupt mode.
-					listening = false
-					// Respond with a true to indicate readiness
-					gComms.InterruptResponseChan <- true
-				}
+				continue
 			}
-		case false:
-			// This is in interrupt mode.
-			select {
-			case interrupt := <-gComms.InterruptRequestChan:
-				if !interrupt {
-					// Resume the detecting routine.
-					controlChan <- true
-					// Switch the state to listening mode.
-					listening = true
-				}
-			case request := <-gComms.CommsRequestChan:
-				// Assume the internal request is always a formatted request
-				err := tcpcomms.SendTCPMessage(writer, request[0], request[1:])
-				if err != nil {
-					// Error here can not be ignored.
-					gComms.CommsResponseError <- err
-					logging.Error1(err)
-					return
-				}
-				// Waiting for a response
-				msgType, data, err := tcpcomms.ReadTCPMessage(reader)
-				if err != nil {
-					if _, ok := err.(*tcpcomms.TimeoutError); ok {
-						// Timeout can be ignored, continue
-						gComms.CommsResponseChan <- nil
-						continue
-					}
-					// Connection error can not be ignored, exit the routine
-					gComms.CommsResponseError <- err
-					logging.Error1(err)
-					return
-				}
-				// Respond to internal requester
-				gComms.CommsResponseChan <- append([]byte{msgType}, data...)
-			}
+		}
+		// Message is invalid.
+		err = tcpcomms.SendInvalidMessage(conn, timeoutDefault*time.Millisecond)
+		if err != nil && !tcpcomms.IsTimeoutError(err) {
+			// Error in tcp communication, drop the connection.
+			logging.Error1(err)
+			return
 		}
 	}
 }
 
-// This starts a go-routine that checks if reader's buffer has any content every 100ms
-// Returns a channel of boolean for trigger and control
-// Send true to control channel to toggle between starting detecting and pausing detecting.
-// By default, detecting is paused.
-// Each time the go-routine detects any incoming messages, it will send a true signal to trigger channel and the detecting is paused.
-func startDetectingRequest(reader *bufio.Reader) (chan bool, chan bool) {
-	triggerChan := make(chan bool)
-	controlChan := make(chan bool)
-	go func(reader *bufio.Reader, triggerChan, controlChan chan bool) {
-		pause := true
-		for {
-			switch pause {
-			case true:
-				// Pausing state
-				control := <-controlChan
-				if control {
-					// Resume
-					pause = false
-				} else {
-					// End routine.
-					return
-				}
-			case false:
-				afterChan := time.After(100 * time.Microsecond)
-				select {
-				case control := <-controlChan:
-					if control {
-						// Pause
-						pause = true
-					} else {
-						// End routine
-						return
-					}
-				case <-afterChan:
-					// Time to check if reader's buffer has any content.
-					if reader.Buffered() > 0 {
-						triggerChan <- true
-						// Change to pause state
-						pause = true
-					}
-				}
-			}
+// GetConnForRequestingGateway returns the connection for sending request to a gateway with given id.
+// It will reuse any active connection.
+func GetConnForRequestingGateway(gatewayID nodeid.NodeID, g *gateway.Gateway) (*gateway.CommunicationChannel, error) {
+	// Check if there is an active connection.
+	g.ActiveGatewaysLock.RLock()
+	gComm := g.ActiveGateways[gatewayID.ToString()]
+	g.ActiveGatewaysLock.RUnlock()
+	if gComm == nil {
+		// No active connection, connect to peer.
+		g.GatewayAddressMapLock.RLock()
+		conn, err := net.Dial("tcp", g.GatewayAddressMap[gatewayID.ToString()])
+		g.GatewayAddressMapLock.RUnlock()
+		if err != nil {
+			return nil, err
 		}
-	}(reader, triggerChan, controlChan)
-	return triggerChan, controlChan
+		gComm = &gateway.CommunicationChannel{
+			CommsLock: sync.RWMutex{},
+			Conn:      conn}
+		if gateway.RegisterGatewayCommunication(&gatewayID, gComm) != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+	return gComm, nil
 }

--- a/internal/api/gatewayapi/gateway_api.go
+++ b/internal/api/gatewayapi/gateway_api.go
@@ -14,9 +14,6 @@ import (
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
 )
 
-// Default timeout for read/write. Unit is in milliseconds.
-const timeoutDefault = 100
-
 // StartGatewayAPI starts the TCP API as a separate go routine.
 func StartGatewayAPI(settings settings.AppSettings, g *gateway.Gateway) error {
 	// Start server
@@ -45,7 +42,7 @@ func handleIncomingGatewayConnection(conn net.Conn, g *gateway.Gateway) {
 
 	// Loop until error occurs and connection is dropped.
 	for {
-		msgType, data, err := tcpcomms.ReadTCPMessage(conn, timeoutDefault*time.Millisecond)
+		msgType, data, err := tcpcomms.ReadTCPMessage(conn, settings.DefaultTCPInactivityTimeoutMs*time.Millisecond)
 		if err != nil && !tcpcomms.IsTimeoutError(err) {
 			// Error in tcp communication, drop the connection.
 			logging.Error1(err)
@@ -65,7 +62,7 @@ func handleIncomingGatewayConnection(conn net.Conn, g *gateway.Gateway) {
 			}
 		}
 		// Message is invalid.
-		err = tcpcomms.SendInvalidMessage(conn, timeoutDefault*time.Millisecond)
+		err = tcpcomms.SendInvalidMessage(conn, settings.DefaultTCPInactivityTimeoutMs*time.Millisecond)
 		if err != nil && !tcpcomms.IsTimeoutError(err) {
 			// Error in tcp communication, drop the connection.
 			logging.Error1(err)

--- a/internal/api/providerapi/dht_publish_groupcid.go
+++ b/internal/api/providerapi/dht_publish_groupcid.go
@@ -1,15 +1,16 @@
 package providerapi
 
 import (
-	"bufio"
 	"encoding/json"
+	"net"
+	"time"
 
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/logging"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/messages"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
 )
 
-func handleProviderDHTPublishGroupCIDRequest(reader *bufio.Reader, writer *bufio.Writer, request *messages.ProviderDHTPublishGroupCIDRequest) error {
+func handleProviderDHTPublishGroupCIDRequest(conn net.Conn, request *messages.ProviderDHTPublishGroupCIDRequest) error {
 	// Do something about the internal request
 	// Will need gateway instance to read from db
 	// gateway, err := gateway.GetSingleInstance()
@@ -19,5 +20,5 @@ func handleProviderDHTPublishGroupCIDRequest(reader *bufio.Reader, writer *bufio
 		MessageType: messages.GatewayDHTDiscoverResponseType,
 		// This is just a dummy response
 	})
-	return tcpcomms.SendTCPMessage(writer, messages.ProviderDHTPublishGroupCIDResponseType, response)
+	return tcpcomms.SendTCPMessage(conn, messages.ProviderDHTPublishGroupCIDResponseType, response, timeoutDefault*time.Millisecond)
 }

--- a/internal/api/providerapi/dht_publish_groupcid.go
+++ b/internal/api/providerapi/dht_publish_groupcid.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/ConsenSys/fc-retrieval-gateway/internal/util/settings"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/logging"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/messages"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
@@ -20,5 +21,5 @@ func handleProviderDHTPublishGroupCIDRequest(conn net.Conn, request *messages.Pr
 		MessageType: messages.GatewayDHTDiscoverResponseType,
 		// This is just a dummy response
 	})
-	return tcpcomms.SendTCPMessage(conn, messages.ProviderDHTPublishGroupCIDResponseType, response, timeoutDefault*time.Millisecond)
+	return tcpcomms.SendTCPMessage(conn, messages.ProviderDHTPublishGroupCIDResponseType, response, settings.DefaultTCPInactivityTimeoutMs*time.Millisecond)
 }

--- a/internal/api/providerapi/provider_api.go
+++ b/internal/api/providerapi/provider_api.go
@@ -1,7 +1,6 @@
 package providerapi
 
 import (
-	"bufio"
 	"encoding/json"
 	"net"
 	"sync"
@@ -11,8 +10,12 @@ import (
 	"github.com/ConsenSys/fc-retrieval-gateway/internal/util/settings"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/logging"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/messages"
+	"github.com/ConsenSys/fc-retrieval-gateway/pkg/nodeid"
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
 )
+
+// Default timeout for read/write. Unit is in milliseconds.
+const timeoutDefault = 100
 
 // StartProviderAPI starts the TCP API as a separate go routine.
 func StartProviderAPI(settings settings.AppSettings, g *gateway.Gateway) error {
@@ -29,193 +32,70 @@ func StartProviderAPI(settings settings.AppSettings, g *gateway.Gateway) error {
 				continue
 			}
 			logging.Info("Incoming connection from provider at :%s\n", conn.RemoteAddr())
-			go handleProviderCommunication(conn, g)
+			go handleIncomingProviderConnection(conn, g)
 		}
 	}(ln)
 	logging.Info("Listening on %s for connections from Providers\n", settings.BindProviderAPI)
 	return nil
 }
 
-func handleProviderCommunication(conn net.Conn, g *gateway.Gateway) {
-	// Initialise a reader and a writer
-	reader := bufio.NewReader(conn)
-	writer := bufio.NewWriter(conn)
-	// Init struct, Set register status to false
-	pComms := gateway.CommunicationChannels{
-		CommsLock:                 sync.RWMutex{},
-		InterruptRequestChan:      make(chan bool),
-		InterruptResponseChan:     make(chan bool),
-		CommsRequestChan:          make(chan []byte),
-		CommsResponseChan:         make(chan []byte),
-		CommsResponseError:        make(chan error),
-		CommsResponseErrorIgnored: make(chan bool),
-	}
-	registered := false
+func handleIncomingProviderConnection(conn net.Conn, g *gateway.Gateway) {
+	// Close connection on exit.
 	defer conn.Close()
-	// Start a go routine checks if any new message from the other gateway
-	triggerChan, controlChan := startDetectingRequest(reader)
-	// switch off control chan on exit to close routine.
-	defer func(controlChan chan bool) {
-		controlChan <- false
-	}(controlChan)
-	// Start detecting
-	controlChan <- true
-	// There are two states, listening mode and interrupt mode.
-	// By default, the thread is in listening mode.
-	listening := true
-	// Start loop
+
+	// Loop until error occurs and connection is dropped.
 	for {
-		switch listening {
-		case true:
-			// This is in listening mode.
-			select {
-			case <-triggerChan:
-				// There is a message received.
-				msgType, data, err := tcpcomms.ReadTCPMessage(reader)
-				if err != nil {
-					// Connection error can not be ignored here. exit the routine.
+		msgType, data, err := tcpcomms.ReadTCPMessage(conn, timeoutDefault*time.Millisecond)
+		if err != nil && !tcpcomms.IsTimeoutError(err) {
+			// Error in tcp communication, drop the connection.
+			logging.Error1(err)
+			return
+		}
+		if msgType == messages.ProviderDHTPublishGroupCIDRequestType {
+			request := messages.ProviderDHTPublishGroupCIDRequest{}
+			if json.Unmarshal(data, &request) == nil {
+				// Message is valid.
+				err = handleProviderDHTPublishGroupCIDRequest(conn, &request)
+				if err != nil && !tcpcomms.IsTimeoutError(err) {
+					// Error in tcp communication, drop the connection.
 					logging.Error1(err)
 					return
 				}
-				// No error in reading the message.
-				if msgType == messages.ProviderDHTPublishGroupCIDRequestType {
-					request := messages.ProviderDHTPublishGroupCIDRequest{}
-					if json.Unmarshal(data, &request) != nil {
-						logging.Warn("Message from provider: %s can not be parsed.\n", conn.RemoteAddr())
-						err = tcpcomms.SendInvalidMessage(writer)
-						if err != nil {
-							// This error can not be ignored. exit the routine.
-							logging.Error1(err)
-							return
-						}
-						// Unable to parse json error can be ignored. continue
-						controlChan <- true
-						continue
-					}
-					// Request is legal and correct.
-					if !registered {
-						// Haven’t registered yet.
-						err = gateway.RegisterProviderCommunication(&request.ProviderID, &pComms)
-						if err != nil {
-							// This provider can not be registered, exit the routine
-							logging.Error1(err)
-							return
-						}
-						// Deregister upon exiting the routine
-						defer gateway.DeregisterProviderCommunication(&request.ProviderID)
-					}
-					// Handle request
-					err = handleProviderDHTPublishGroupCIDRequest(reader, writer, &request)
-					if err != nil {
-						// Connection error can not be ignored here. exit the routine.
-						logging.Error1(err)
-						return
-					}
-				} else {
-					logging.Warn("Message from provider: %s is of wrong type", conn.RemoteAddr())
-					err = tcpcomms.SendInvalidMessage(writer)
-					if err != nil {
-						// Connection error can not be ignored here. exit the routine.
-						logging.Error1(err)
-						return
-					}
-				}
-				// The request has been handled properly. Resume the detecting routine.
-				controlChan <- true
-			case interrupt := <-pComms.InterruptRequestChan:
-				if interrupt {
-					// Pause the detecting routine.
-					controlChan <- true
-					// Switch the state to interrupt mode.
-					listening = false
-					// Respond with a true to indicate readiness
-					pComms.InterruptResponseChan <- true
-				}
+				continue
 			}
-		case false:
-			// This is in interrupt mode.
-			select {
-			case interrupt := <-pComms.InterruptRequestChan:
-				if !interrupt {
-					// Resume the detecting routine.
-					controlChan <- true
-					// Switch the state to listening mode.
-					listening = true
-				}
-			case request := <-pComms.CommsRequestChan:
-				// Assume the internal request is always a formatted request
-				err := tcpcomms.SendTCPMessage(writer, request[0], request[1:])
-				if err != nil {
-					// Error here can not be ignored.
-					pComms.CommsResponseError <- err
-					logging.Error1(err)
-					return
-				}
-				// Waiting for a response
-				msgType, data, err := tcpcomms.ReadTCPMessage(reader)
-				if err != nil {
-					if _, ok := err.(*tcpcomms.TimeoutError); ok {
-						// Timeout can be ignored, continue
-						pComms.CommsResponseChan <- nil
-						continue
-					}
-					// Connection error can not be ignored, exit the routine
-					pComms.CommsResponseError <- err
-					logging.Error1(err)
-					return
-				}
-				// Respond to internal requester
-				pComms.CommsResponseChan <- append([]byte{msgType}, data...)
-			}
+		}
+		// Message is invalid.
+		err = tcpcomms.SendInvalidMessage(conn, timeoutDefault*time.Millisecond)
+		if err != nil && !tcpcomms.IsTimeoutError(err) {
+			// Error in tcp communication, drop the connection.
+			logging.Error1(err)
+			return
 		}
 	}
 }
 
-// This starts a go-routine that checks if reader's buffer has any content every 100ms
-// Returns a channel of boolean for trigger and control
-// Send true to control channel to toggle between starting detecting and pausing detecting.
-// By default, detecting is paused. Each time
-// Send the channel with a true to toggle between starting detecting and pausing detecting, by default, the detecting is paused.
-// Send the channel with a false to shutdown the go routine.
-// The channel will gets a true signal if there is content detected.
-func startDetectingRequest(reader *bufio.Reader) (chan bool, chan bool) {
-	triggerChan := make(chan bool)
-	controlChan := make(chan bool)
-	go func(reader *bufio.Reader, triggerChan, controlChan chan bool) {
-		pause := true
-		for {
-			switch pause {
-			case true:
-				// Pausing state
-				control := <-controlChan
-				if control {
-					// Resume
-					pause = false
-				} else {
-					// End routine.
-					return
-				}
-			case false:
-				afterChan := time.After(100 * time.Microsecond)
-				select {
-				case control := <-controlChan:
-					if control {
-						// Pause
-						pause = true
-					} else {
-						// End routine
-						return
-					}
-				case <-afterChan:
-					// Time to check if reader's buffer has any content.
-					if reader.Buffered() > 0 {
-						triggerChan <- true
-						// Change to pause state
-						pause = true
-					}
-				}
-			}
+// GetConnForRequestingProvider returns the connection for sending request to a provider with given id.
+// It will reuse any active connection.
+func GetConnForRequestingProvider(providerID nodeid.NodeID, g *gateway.Gateway) (*gateway.CommunicationChannel, error) {
+	// Check if there is an active connection.
+	g.ActiveProvidersLock.RLock()
+	pComm := g.ActiveProviders[providerID.ToString()]
+	g.ActiveProvidersLock.RUnlock()
+	if pComm == nil {
+		// No active connection, connect to peer.
+		g.ProviderAddressMapLock.RLock()
+		conn, err := net.Dial("tcp", g.ProviderAddressMap[providerID.ToString()])
+		g.ProviderAddressMapLock.RUnlock()
+		if err != nil {
+			return nil, err
 		}
-	}(reader, triggerChan, controlChan)
-	return triggerChan, controlChan
+		pComm = &gateway.CommunicationChannel{
+			CommsLock: sync.RWMutex{},
+			Conn:      conn}
+		if gateway.RegisterProviderCommunication(&providerID, pComm) != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+	return pComm, nil
 }

--- a/internal/api/providerapi/provider_api.go
+++ b/internal/api/providerapi/provider_api.go
@@ -14,9 +14,6 @@ import (
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/tcpcomms"
 )
 
-// Default timeout for read/write. Unit is in milliseconds.
-const timeoutDefault = 100
-
 // StartProviderAPI starts the TCP API as a separate go routine.
 func StartProviderAPI(settings settings.AppSettings, g *gateway.Gateway) error {
 	// Start server
@@ -45,7 +42,7 @@ func handleIncomingProviderConnection(conn net.Conn, g *gateway.Gateway) {
 
 	// Loop until error occurs and connection is dropped.
 	for {
-		msgType, data, err := tcpcomms.ReadTCPMessage(conn, timeoutDefault*time.Millisecond)
+		msgType, data, err := tcpcomms.ReadTCPMessage(conn, settings.DefaultTCPInactivityTimeoutMs*time.Millisecond)
 		if err != nil && !tcpcomms.IsTimeoutError(err) {
 			// Error in tcp communication, drop the connection.
 			logging.Error1(err)
@@ -65,7 +62,7 @@ func handleIncomingProviderConnection(conn net.Conn, g *gateway.Gateway) {
 			}
 		}
 		// Message is invalid.
-		err = tcpcomms.SendInvalidMessage(conn, timeoutDefault*time.Millisecond)
+		err = tcpcomms.SendInvalidMessage(conn, settings.DefaultTCPInactivityTimeoutMs*time.Millisecond)
 		if err != nil && !tcpcomms.IsTimeoutError(err) {
 			// Error in tcp communication, drop the connection.
 			logging.Error1(err)

--- a/internal/util/settings/settings.go
+++ b/internal/util/settings/settings.go
@@ -25,6 +25,9 @@ const settingsDefaultPrivateKey = "01"
 const settingsDefaultPrivKeyVer = 0xff
 const settingsDefaultPrivKeySigAlg = 0xff
 
+// DefaultTCPInactivityTimeoutMs is the default timeout for TCP inactivity
+const DefaultTCPInactivityTimeoutMs = 100
+
 // AppSettings defines the server configuraiton
 type AppSettings struct {
 	BindRestAPI     string `json:"bindrestapi"`     // Port number to bind to for client REST API.

--- a/pkg/tcpcomms/tcp_comms.go
+++ b/pkg/tcpcomms/tcp_comms.go
@@ -5,66 +5,66 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"io"
+	"net"
 	"time"
 
 	"github.com/ConsenSys/fc-retrieval-gateway/pkg/messages"
 )
 
-// ReadTCPMessage read the tcp message from a given reader
-func ReadTCPMessage(reader *bufio.Reader) (byte, []byte, error) {
-	afterChan := time.After(30 * time.Second) // TODO: The timeout default value is 30, it should be configurable.
-	triggerChan := make(chan bool)
-	var request []byte
-	var err error
-	go func(reader *bufio.Reader, triggerChan chan bool) {
-		// TODO: Need to check. Here assumes each tcp message starts with
-		// (length four bytes big endian, msg_type one byte)
-		length := make([]byte, 4)
-		_, err = io.ReadFull(reader, length)
-		if err != nil {
-			triggerChan <- true
-		}
+// IsTimeoutError checks if the given error is a timeout error
+func IsTimeoutError(err error) bool {
+	neterr, ok := err.(net.Error)
+	return ok && neterr.Timeout()
+}
 
-		// Get request
-		request = make([]byte, binary.BigEndian.Uint32(length))
-		_, err = io.ReadFull(reader, request)
-		if err != nil {
-			triggerChan <- true
-		}
-		triggerChan <- true
-	}(reader, triggerChan)
-	select {
-	case <-afterChan:
-		return 0, nil, &TimeoutError{}
-	case <-triggerChan:
-		if err != nil {
-			return 0, nil, err
-		}
-		return request[0], request[1:], nil
+// ReadTCPMessage read the tcp message from a given connection
+func ReadTCPMessage(conn net.Conn, timeout time.Duration) (byte, []byte, error) {
+	// Initialise a reader
+	reader := bufio.NewReader(conn)
+	// Read the length
+	length := make([]byte, 4)
+	// Set timeout
+	conn.SetDeadline(time.Now().Add(timeout))
+	_, err := io.ReadFull(reader, length)
+	if err != nil {
+		return 0, nil, err
 	}
+	// Read the request
+	request := make([]byte, int(binary.BigEndian.Uint32(length)))
+	// Set timeout
+	conn.SetDeadline(time.Now().Add(timeout))
+	_, err = io.ReadFull(reader, request)
+	if err != nil {
+		return 0, nil, err
+	}
+	return request[0], request[1:], nil
 }
 
 // SendTCPMessage sends a tcp message to a given writer
-func SendTCPMessage(writer *bufio.Writer, msgType byte, data []byte) error {
-	// TODO: Here assumes each tcp message starts with
-	// (length four bytes big endian, msg_type one byte)
+func SendTCPMessage(conn net.Conn, msgType byte, data []byte, timeout time.Duration) error {
+	// Initialise a writer
+	writer := bufio.NewWriter(conn)
 	length := make([]byte, 4)
 	binary.BigEndian.PutUint32(length, uint32(1+len(data)))
+	// Set timeout
+	conn.SetDeadline(time.Now().Add(timeout))
 	_, err := writer.Write(append(append(length, msgType), data...))
 	if err != nil {
 		return err
 	}
+	// Set timeout
+	conn.SetDeadline(time.Now().Add(timeout))
 	return writer.Flush()
 }
 
 // SendProtocolMismatch sends a protocol mistmatch message to a given writer
-func SendProtocolMismatch(writer *bufio.Writer) error {
+func SendProtocolMismatch(conn net.Conn, timeout time.Duration) error {
 	data, _ := json.Marshal(messages.ProtocolMismatchResponse{MessageType: messages.ProtocolMismatch})
-	return SendTCPMessage(writer, messages.ProtocolMismatch, data)
+	return SendTCPMessage(conn, messages.ProtocolMismatch, data, timeout)
 }
 
 // SendInvalidMessage sends an invalid message to a given writer
-func SendInvalidMessage(writer *bufio.Writer) error {
+func SendInvalidMessage(conn net.Conn, timeout time.Duration) error {
 	data, _ := json.Marshal(messages.InvalidMessageResponse{MessageType: messages.InvalidMessage})
-	return SendTCPMessage(writer, messages.InvalidMessage, data)
+	return SendTCPMessage(conn, messages.InvalidMessage, data, timeout)
 }

--- a/pkg/tcpcomms/timeout_error.go
+++ b/pkg/tcpcomms/timeout_error.go
@@ -1,9 +1,0 @@
-package tcpcomms
-
-// TimeoutError is used when the other party does not respond within a given time,
-// it should be ignored.
-type TimeoutError struct{}
-
-func (t *TimeoutError) Error() string {
-	return "Communication timeout."
-}


### PR DESCRIPTION
This pull request decouples the old problematic TCP communication. TCP server port will only respond to any incoming TCP request. For any outgoing request, the node will connect to the peer's TCP server port and use this socket for any future request. They are now independent of each other.